### PR TITLE
Add Inactive account endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ test/e2e/kratos.*.yml
 __debug_bin*
 .debug.sqlite.db
 .last-run.json
+.env

--- a/.schema/version.schema.json
+++ b/.schema/version.schema.json
@@ -7,6 +7,23 @@
             {
                 "properties": {
                     "version": {
+                        "const": "v1.5.0"
+                    }
+                },
+                "required": [
+                    "version"
+                ]
+            },
+            {
+                "$ref": "https://raw.githubusercontent.com/nayla-finance/kratos/v1.5.0/.schemastore/config.schema.json"
+            }
+        ]
+    },
+      {
+        "allOf": [
+            {
+                "properties": {
+                    "version": {
                         "const": "v1.4.0"
                     }
                 },

--- a/.schemastore/config.schema.json
+++ b/.schemastore/config.schema.json
@@ -1310,12 +1310,14 @@
                   "properties": {
                     "attempt_window": {
                       "type": "string",
+                      "description": "The time window in which login attempts are considered. After this window, failed attempts are forgotten.",
                       "pattern": "^([0-9]+(s|m|h))+$",
                       "default": "5m",
                       "examples": ["1h", "1m", "30s"]
                     },
                     "max_attempts": {
                       "type": "number",
+                      "description": "The maximum number of failed login attempts (within the attempt window) before a user is blocked.",
                       "default": "3",
                       "examples": ["3", "5"]
                     }
@@ -2060,6 +2062,9 @@
                   "properties": {
                     "email": {
                       "$ref": "#/definitions/emailCourierTemplate"
+                    },
+                    "sms": {
+                      "$ref": "#/definitions/smsCourierTemplate"
                     }
                   },
                   "required": ["email"]
@@ -2644,6 +2649,15 @@
             },
             "required": ["id", "url"]
           }
+        },
+        "inactivity_threshold_in_months": {
+          "title": "Identity Inactivity Threshold",
+          "description": "The period (in months) after which an identity is considered inactive if there are no active sessions for it.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 12,
+          "default": 6,
+          "examples": [1, 6, 12]
         }
       },
       "required": ["schemas"],

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -169,6 +169,7 @@ const (
 	ViperKeySelfServiceVerificationNotifyUnknownRecipients   = "selfservice.flows.verification.notify_unknown_recipients"
 	ViperKeyDefaultIdentitySchemaID                          = "identity.default_schema_id"
 	ViperKeyIdentitySchemas                                  = "identity.schemas"
+	ViperKeyIdentityInactivityThresholdInMonths              = "identity.identity_inactivity_threshold_in_months"
 	ViperKeyHasherAlgorithm                                  = "hashers.algorithm"
 	ViperKeyHasherArgon2ConfigMemory                         = "hashers.argon2.memory"
 	ViperKeyHasherArgon2ConfigIterations                     = "hashers.argon2.iterations"
@@ -604,6 +605,10 @@ func (p *Config) DefaultIdentityTraitsSchemaURL(ctx context.Context) (*url.URL, 
 
 func (p *Config) DefaultIdentityTraitsSchemaID(ctx context.Context) string {
 	return p.GetProvider(ctx).String(ViperKeyDefaultIdentitySchemaID)
+}
+
+func (p *Config) IdentityInactivityThresholdInMonths(ctx context.Context) int {
+	return p.GetProvider(ctx).IntF(ViperKeyIdentityInactivityThresholdInMonths, 12)
 }
 
 func (p *Config) TOTPIssuer(ctx context.Context) string {

--- a/driver/config/config.go
+++ b/driver/config/config.go
@@ -169,7 +169,7 @@ const (
 	ViperKeySelfServiceVerificationNotifyUnknownRecipients   = "selfservice.flows.verification.notify_unknown_recipients"
 	ViperKeyDefaultIdentitySchemaID                          = "identity.default_schema_id"
 	ViperKeyIdentitySchemas                                  = "identity.schemas"
-	ViperKeyIdentityInactivityThresholdInMonths              = "identity.identity_inactivity_threshold_in_months"
+	ViperKeyIdentityInactivityThresholdInMonths              = "identity.inactivity_threshold_in_months"
 	ViperKeyHasherAlgorithm                                  = "hashers.algorithm"
 	ViperKeyHasherArgon2ConfigMemory                         = "hashers.argon2.memory"
 	ViperKeyHasherArgon2ConfigIterations                     = "hashers.argon2.iterations"

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -2647,6 +2647,15 @@
             },
             "required": ["id", "url"]
           }
+        },
+        "inactivity_threshold_in_months": {
+          "title": "Identity Inactivity Threshold",
+          "description": "The period (in months) after which an identity is considered inactive if there are no active sessions for it.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 12,
+          "default": 6,
+          "examples": [1, 6, 12]
         }
       },
       "required": ["schemas"],

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -1310,12 +1310,14 @@
                   "properties": {
                     "attempt_window": {
                       "type": "string",
+                      "description": "The time window in which login attempts are considered. After this window, failed attempts are forgotten.",
                       "pattern": "^([0-9]+(s|m|h))+$",
                       "default": "5m",
                       "examples": ["1h", "1m", "1s"]
                     },
                     "max_attempts": {
                       "type": "number",
+                      "description": "The maximum number of failed login attempts (within the attempt window) before a user is blocked.",
                       "default": "3",
                       "examples": ["3", "5"]
                     }

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -1076,20 +1076,23 @@ func (h *Handler) listInactiveIdentities(w http.ResponseWriter, r *http.Request,
 	}
 
 	identities := make([]map[string]interface{}, len(inactiveIdentities))
-	ids := make([]string, len(inactiveIdentities))
-	for i, id := range inactiveIdentities {
-		identities[i] = map[string]interface{}{
-			"id":         id.ID,
-			"state":      id.State,
-			"created_at": id.CreatedAt,
-			"updated_at": id.UpdatedAt,
-		}
-		ids[i] = id.ID.String()
-	}
 
-	if err := h.r.IdentityManager().DeactivateIdentities(r.Context(), ids); err != nil {
-		h.r.Writer().WriteError(w, r, err)
-		return
+	if len(inactiveIdentities) > 0 {
+		ids := make([]string, len(inactiveIdentities))
+		for i, id := range inactiveIdentities {
+			identities[i] = map[string]interface{}{
+				"id":         id.ID,
+				"state":      id.State,
+				"created_at": id.CreatedAt,
+				"updated_at": id.UpdatedAt,
+			}
+			ids[i] = id.ID.String()
+		}
+
+		if err := h.r.IdentityManager().DeactivateIdentities(r.Context(), ids); err != nil {
+			h.r.Writer().WriteError(w, r, err)
+			return
+		}
 	}
 
 	h.r.Writer().Write(w, r, identities)

--- a/identity/handler.go
+++ b/identity/handler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -43,6 +44,8 @@ const (
 	RouteCollection     = "/identities"
 	RouteItem           = RouteCollection + "/:id"
 	RouteCredentialItem = RouteItem + "/credentials/:type"
+
+	AdminRouteInactiveIdentities = "inactive-identities"
 
 	BatchPatchIdentitiesLimit = 2000
 )
@@ -114,6 +117,8 @@ func (h *Handler) RegisterAdminRoutes(admin *x.RouterAdmin) {
 	admin.PUT(RouteItem, h.update)
 
 	admin.DELETE(RouteCredentialItem, h.deleteIdentityCredentials)
+
+	admin.PUT(AdminRouteInactiveIdentities, h.listInactiveIdentities)
 }
 
 // Paginated Identity List Response
@@ -1022,4 +1027,70 @@ func (h *Handler) deleteIdentityCredentials(w http.ResponseWriter, r *http.Reque
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// swagger:route PUT /admin/inactive-identities identity listInactiveIdentities
+//
+// # List Inactive Identities
+//
+// Lists and deactivates identities that have been inactive for a configurable period of time. An identity is considered
+// inactive if it has no active sessions within the configured inactivity threshold period. The endpoint
+// returns basic identity information including ID, state, and timestamps.
+//
+// This endpoint will run deactivation logic on all identities who have not been active for X months.
+//
+//	Produces:
+//	- application/json
+//
+//	Schemes: http, https
+//
+//	Security:
+//	  oryAccessToken:
+//
+//	Query Parameters:
+//	  limit: The maximum number of identities to return.
+//
+//	Responses:
+//	  200: listInactiveIdentitiesResponse
+//	  400: errorGeneric
+//	  default: errorGeneric
+func (h *Handler) listInactiveIdentities(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+	if err != nil {
+		limit = 50 // Default limit
+	}
+
+	if limit <= 0 {
+		h.r.Writer().WriteError(w, r, errors.WithStack(herodot.ErrBadRequest.WithReasonf("Limit must be greater than 0.")))
+		return
+	}
+
+	inactiveIdentities, err := h.r.IdentityManager().ListIdentitiesForDeactivation(
+		r.Context(),
+		h.r.Config().IdentityInactivityThresholdInMonths(r.Context()),
+		limit,
+	)
+	if err != nil {
+		h.r.Writer().WriteError(w, r, err)
+		return
+	}
+
+	identities := make([]map[string]interface{}, len(inactiveIdentities))
+	ids := make([]string, len(inactiveIdentities))
+	for i, id := range inactiveIdentities {
+		identities[i] = map[string]interface{}{
+			"id":         id.ID,
+			"state":      id.State,
+			"created_at": id.CreatedAt,
+			"updated_at": id.UpdatedAt,
+		}
+		ids[i] = id.ID.String()
+	}
+
+	if err := h.r.IdentityManager().DeactivateIdentities(r.Context(), ids); err != nil {
+		h.r.Writer().WriteError(w, r, err)
+		return
+	}
+
+	h.r.Writer().Write(w, r, identities)
 }

--- a/identity/manager.go
+++ b/identity/manager.go
@@ -337,6 +337,7 @@ func (e *CreateIdentitiesError) Error() string {
 	e.init()
 	return fmt.Sprintf("create identities error: %d identities failed", len(e.failedIdentities))
 }
+
 func (e *CreateIdentitiesError) Unwrap() []error {
 	e.init()
 	var errs []error
@@ -350,17 +351,20 @@ func (e *CreateIdentitiesError) AddFailedIdentity(ident *Identity, err *herodot.
 	e.init()
 	e.failedIdentities[ident] = err
 }
+
 func (e *CreateIdentitiesError) Merge(other *CreateIdentitiesError) {
 	e.init()
 	for k, v := range other.failedIdentities {
 		e.failedIdentities[k] = v
 	}
 }
+
 func (e *CreateIdentitiesError) Contains(ident *Identity) bool {
 	e.init()
 	_, found := e.failedIdentities[ident]
 	return found
 }
+
 func (e *CreateIdentitiesError) Find(ident *Identity) *FailedIdentity {
 	e.init()
 	if err, found := e.failedIdentities[ident]; found {
@@ -369,12 +373,14 @@ func (e *CreateIdentitiesError) Find(ident *Identity) *FailedIdentity {
 
 	return nil
 }
+
 func (e *CreateIdentitiesError) ErrOrNil() error {
 	if e.failedIdentities == nil || len(e.failedIdentities) == 0 {
 		return nil
 	}
 	return e
 }
+
 func (e *CreateIdentitiesError) init() {
 	if e.failedIdentities == nil {
 		e.failedIdentities = map[*Identity]*herodot.DefaultError{}
@@ -583,4 +589,13 @@ func (m *Manager) CountActiveMultiFactorCredentials(ctx context.Context, i *Iden
 		count += current
 	}
 	return count, nil
+}
+
+func (m *Manager) ListIdentitiesForDeactivation(ctx context.Context, period int, limit int) (identities []*Identity, err error) {
+	m.r.Logger().Println("Listing identities to deactivate")
+	return m.r.PrivilegedIdentityPool().ListIdentitiesForDeactivation(ctx, period, limit)
+}
+
+func (m *Manager) DeactivateIdentities(ctx context.Context, ids []string) (err error) {
+	return m.r.PrivilegedIdentityPool().DeactivateIdentities(ctx, ids)
 }

--- a/identity/pool.go
+++ b/identity/pool.go
@@ -114,6 +114,12 @@ type (
 
 		// FindIdentityByWebauthnUserHandle returns an identity matching a webauthn user handle.
 		FindIdentityByWebauthnUserHandle(ctx context.Context, userHandle []byte) (*Identity, error)
+
+		// ListIdentitiesForDeactivation lists identities that have not been active for a given period.
+		ListIdentitiesForDeactivation(ctx context.Context, period int, limit int) ([]*Identity, error)
+
+		// DeactivateIdentities deactivates identities.
+		DeactivateIdentities(ctx context.Context, ids []string) error
 	}
 )
 


### PR DESCRIPTION
# Inactive Account Management

## Changes Made
- Added configuration options for account inactivity management:
  - Inactivity threshold period configuration
  - Custom schema modifications to support new settings
- Implemented new API endpoints:
  - PUT endpoint to list inactive identities and deactivate them
- Added database layer support:
  - SQL queries for identifying inactive accounts based on last activity
  - Update operations for account deactivation
- Implemented business logic:
  - Manager methods for inactive account detection
  - Persister methods for handling deactivation states
  - Activity tracking mechanisms

## Why
To enhance security and resource management by automatically identifying and handling dormant accounts. This feature allows administrators to:
- Monitor account activity patterns
- Enforce account lifecycle policies
- Maintain cleaner user databases
- Reduce security risks from abandoned accounts

## Technical Details
- Extended Kratos schema to include inactivity configuration
- Added persistence layer modifications for tracking last activity
- Implemented RESTful endpoints for administrative control